### PR TITLE
Update for 1.12 of Minecraft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ MAINTAINER Michael Chiang <mchiang@docker.com>
 RUN apt-get -y update
 RUN apt-get -y install openjdk-7-jre-headless wget
 
+# Minecraft Server Version to download
+ENV MINECRAFT_VERSION 1.12
+
 # Download Minecraft Server components
-RUN wget -q https://s3.amazonaws.com/Minecraft.Download/versions/1.12/minecraft_server.1.12.jar
+RUN wget -q https://s3.amazonaws.com/Minecraft.Download/versions/${MINECRAFT_VERSION}/minecraft_server.${MINECRAFT_VERSION}.jar
 
 # Sets working directory for the CMD instruction (also works for RUN, ENTRYPOINT commands)
 # Create mount point, and mark it as holding externally mounted volume
@@ -23,4 +26,4 @@ VOLUME /data
 EXPOSE 25565
 
 #Automatically accept Minecraft EULA, and start Minecraft server
-CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.1.12.jar
+CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.${MINECRAFT_VERSION}.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -y update
 RUN apt-get -y install openjdk-7-jre-headless wget
 
 # Download Minecraft Server components
-RUN wget -q https://s3.amazonaws.com/Minecraft.Download/versions/1.11.2/minecraft_server.1.11.2.jar
+RUN wget -q https://s3.amazonaws.com/Minecraft.Download/versions/1.12/minecraft_server.1.12.jar
 
 # Sets working directory for the CMD instruction (also works for RUN, ENTRYPOINT commands)
 # Create mount point, and mark it as holding externally mounted volume
@@ -23,4 +23,4 @@ VOLUME /data
 EXPOSE 25565
 
 #Automatically accept Minecraft EULA, and start Minecraft server
-CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.1.11.2.jar
+CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.1.12.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Michael Chiang <mchiang@docker.com>
 # Use APT (Advanced Packaging Tool) built in the Linux distro to download Java, a dependency
 # to run Minecraft.
 RUN apt-get -y update
-RUN apt-get -y install openjdk-7-jre-headless wget
+RUN apt-get -y install openjdk-8-jre-headless wget
 
 # Minecraft Server Version to download
 ENV MINECRAFT_VERSION 1.12
@@ -26,4 +26,4 @@ VOLUME /data
 EXPOSE 25565
 
 #Automatically accept Minecraft EULA, and start Minecraft server
-CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.${MINECRAFT_VERSION}.jar
+CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.${MINECRAFT_VERSION}.jar nogui


### PR DESCRIPTION
Start pulling in the 1.12 jar file instead of 1.11.2.