### PR TITLE
Become version agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # Minecraft 1.11 Dockerfile - Example with notes
 
-# Use the offical Debian Docker image with a specified version tag, Jessie, so not all
+# Use the offical Debian Docker image with a specified version tag, Stretch, so not all
 # versions of Debian images are downloaded.
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Michael Chiang <mchiang@docker.com>
 
-# Drives which version we are going to install
-ENV MINECRAFT_VERSION 1.13.2
+# Simple utility for download a specific version of the minecraft server.jar
+ENV MINECRAFT_UTILITY https://github.com/marblenix/minecraft_downloader/releases/download/20190324-f1427be/minecraft_downloader_linux
+# Version of minecraft to download
+ENV MINECRAFT_VERSION latest
 
 # Use APT (Advanced Packaging Tool) built in the Linux distro to download Java, a dependency
 # to run Minecraft.
@@ -16,10 +18,11 @@ ENV MINECRAFT_VERSION 1.13.2
 # Then we pull in all of our dependencies, 
 # Finally, we download the correct .jar file using wget
 # .jar file fetched from the official page https://minecraft.net/en-us/download/server/
-RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list; \
-    apt-get -y update; \
-    apt install -y -t jessie-backports openjdk-8-jre-headless ca-certificates-java wget; \
-    wget -q https://launcher.mojang.com/v1/objects/3737db93722a9e39eeada7c27e7aca28b144ffa7/server.jar -O /minecraft_server.${MINECRAFT_VERSION}.jar;
+RUN apt update; \
+    apt install -y default-jre ca-certificates-java curl; \
+    curl -sL "${MINECRAFT_UTILITY}" -o minecraft_downloader; \
+    chmod +x ./minecraft_downloader; \
+    ./minecraft_downloader -o minecraft_server_${MINECRAFT_VERSION}.jar;
 # We do the above in a single line to reduce the number of layers in our container
 
 # Sets working directory for the CMD instruction (also works for RUN, ENTRYPOINT commands)
@@ -31,4 +34,4 @@ VOLUME /data
 EXPOSE 25565
 
 #Automatically accept Minecraft EULA, and start Minecraft server
-CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server.${MINECRAFT_VERSION}.jar
+CMD echo eula=true > /data/eula.txt && java -jar /minecraft_server_${MINECRAFT_VERSION}.jar


### PR DESCRIPTION
Do not rely on manually updating the minecraft server information

Instead download the main manifest from launchermeta.mojang.com and parse with jq to get the latest download url.

The new steps are:

1. Download the client/server version manifest from https://launchermeta.mojang.com/mc/game/version_manifest.json
2. get the latest version from .latest.release (1.13.2 at the time of this pull request)
3. get the version manifest from the same file that matches the latest release version
4. download the release version manifest and parse it for the server download url
5. download the client to /minecraft_server.${MINECRAFT_VERSION}.jar

See: https://gaming.stackexchange.com/questions/123194/is-there-a-way-to-get-the-latest-server-jar-through-a-url-that-doesnt-change

other changes:
- I switched the script to use curl instead of wget
- latest version is saved to /latest which needs to be sourced before ${MINECRAFT_VERSION} can be used at runtime