### PR TITLE
update download utility url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Michael Chiang <mchiang@docker.com>
 
 # Simple utility for download a specific version of the minecraft server.jar
-ENV MINECRAFT_UTILITY https://github.com/marblenix/minecraft_downloader/releases/download/20190324-f1427be/minecraft_downloader_linux
+ENV MINECRAFT_UTILITY https://github.com/marblenix/minecraft_downloader/releases/download/latest/minecraft_downloader_linux
 # Version of minecraft to download
 ENV MINECRAFT_VERSION latest
 


### PR DESCRIPTION
Use an always up-to-date link for the minecraft downloader utility

Hello, me again. I spent a bit of time working out how to get automated travis builds always deploy to the same release, so that the utility will always be up-to-date.

I've kept the old releases around, and they'll always be around, but I wanted to make this one less thing you had to keep track of.